### PR TITLE
Rename belief 'name' field to 'description'

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -202,7 +202,7 @@ absent — 0.4 is the floor.
 
 **The Icon-and-Label Rule.** A source is *always* backed by its icon and label, never
 color alone — chips (colored icon + tinted pill + **ink** label), forms, and the node's
-own name below the donut. Meaning-bearing text stays in ink so it clears contrast on any
+own description below the donut. Meaning-bearing text stays in ink so it clears contrast on any
 hue.
 
 **The Lift-by-Light Rule.** On this dark theme depth comes from surface *lightness*
@@ -220,14 +220,14 @@ system the user already trusts, not a branded voice competing with their beliefs
 Hierarchy comes from **weight (400 → 600 → 700) and size**, never from a second family.
 
 ### Hierarchy
-- **Title** (600, 1.15rem, line-height 1.2): the selected belief's name in the detail
+- **Title** (600, 1.15rem, line-height 1.2): the selected belief's description in the detail
   panel — the largest text in the app.
 - **Headline** (600, 1.05–1.1rem): app-bar brand ("Belief Map") and modal headers.
 - **Body** (400, 0.9–0.95rem, line-height 1.5): belief notes, references, menu items,
   button labels. Cap prose at 65–75ch inside panels.
 - **Label** (600, 0.8rem): form field labels and section headers — often in Ink Muted.
-- **Node Label** (500, 12px): the belief name under each donut on the field; turns
-  Constellation Indigo at weight 700 when its node is selected. Names over 20 chars are
+- **Node Label** (500, 12px): the belief description under each donut on the field; turns
+  Constellation Indigo at weight 700 when its node is selected. Long descriptions are
   truncated with an ellipsis.
 - **Micro** (400, 0.72–0.75rem): hints and inline validation errors only.
 
@@ -309,7 +309,7 @@ made explicit where there's room for it.
 ### Inputs / Fields
 - **Style:** dark Surface, 1px Border, 8px radius; label above in Ink-Muted 0.8rem/600.
   Native `<select>` for the source-category and confidence pickers (the belief form pairs
-  them side by side); `<input>`/`<textarea>` for name, notes, and reference rows.
+  them side by side); `<textarea>` for the description and notes, `<input>` for reference rows.
 - **Focus:** a 2px iris outline at 40% (`color-mix`) plus a solid iris border — a soft
   focus glow, clearly visible, never a hard system ring.
 - **Error:** inline Danger micro text below the field; validation is deferred until an
@@ -334,7 +334,7 @@ chrome never looks like a third-party default:
 ### The Reroute Modal (move a belief)
 A focused modal for re-parenting: a hint line naming the current parent, an optional search
 box (shown only past 8 candidates), and a scrollable, depth-indented list of eligible target
-beliefs — each a full-width row with the target's category **dot**, its name, and a trailing
+beliefs — each a full-width row with the target's category **dot**, its description, and a trailing
 chevron. Hover paints a 9% iris wash. It exists so structural edits stay light and reversible.
 
 ### The Belief Node (signature component)
@@ -344,7 +344,7 @@ arc *width* scaled by count, arc *opacity* by average child confidence) show the
 mix, and an inner ring stroked in the node's own source hue at its own confidence opacity.
 Radius is 25px at rest and inflates to 37px on hover with a 0.18s ease — soft and springy,
 inviting a poke. A small collapse/expand badge (± in a bordered `surface-raised` circle)
-sits at the node's shoulder when it has children. The name label sits below; selection
+sits at the node's shoulder when it has children. The description label sits below; selection
 turns it iris and bold. This is where "inviting to tinker" and "legible structure over
 decoration" both live — protect it.
 

--- a/src/lib/components/BeliefCardNode.svelte
+++ b/src/lib/components/BeliefCardNode.svelte
@@ -39,8 +39,8 @@
 	class:selected={ui.selectedId === node.id}
 	role="button"
 	tabindex="0"
-	aria-label={i18n.m.node.belief({ name: node.name })}
-	title={node.name}
+	aria-label={i18n.m.node.belief({ description: node.description })}
+	title={node.description}
 	onmouseenter={() => (hovered = true)}
 	onmouseleave={() => (hovered = false)}
 	onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && (e.preventDefault(), open())}
@@ -60,7 +60,7 @@
 		<Icon name={own.icon} size={15} />
 	</span>
 
-	<div class="name">{node.name}</div>
+	<div class="description">{node.description}</div>
 
 	<!-- Edit affordance (hover), stacked above the collapse badge. -->
 	{#if hovered}
@@ -138,7 +138,7 @@
 		line-height: 0;
 	}
 
-	.name {
+	.description {
 		display: -webkit-box;
 		-webkit-box-orient: vertical;
 		-webkit-line-clamp: 3;
@@ -152,7 +152,7 @@
 		line-height: 1.25;
 		color: var(--text);
 	}
-	.card.selected .name {
+	.card.selected .description {
 		color: var(--accent);
 		font-weight: 700;
 	}

--- a/src/lib/components/BeliefDetails.svelte
+++ b/src/lib/components/BeliefDetails.svelte
@@ -24,7 +24,7 @@
 	}
 	function copy() {
 		ui.copy({
-			name: node.name,
+			description: node.description,
 			notes: node.notes,
 			source: node.source,
 			confidence: node.confidence,
@@ -60,7 +60,7 @@
 		<span class="conf-label">{conf.label}</span>
 	</div>
 
-	<h2>{node.name}</h2>
+	<h2>{node.description}</h2>
 
 	{#if node.notes}
 		<p class="notes">{node.notes}</p>

--- a/src/lib/components/BeliefDonutNode.svelte
+++ b/src/lib/components/BeliefDonutNode.svelte
@@ -25,7 +25,9 @@
 	// opacity = the average confidence of the children in that category group.
 	const segments = $derived.by(() => computeSegments(node));
 
-	const label = $derived(node.name.length > 100 ? node.name.slice(0, 99) + '…' : node.name);
+	const label = $derived(
+		node.description.length > 100 ? node.description.slice(0, 99) + '…' : node.description
+	);
 
 	function open() {
 		ui.select(node.id);
@@ -45,8 +47,8 @@
 	class:selected={ui.selectedId === node.id}
 	role="button"
 	tabindex="0"
-	aria-label={i18n.m.node.belief({ name: node.name })}
-	title={node.name}
+	aria-label={i18n.m.node.belief({ description: node.description })}
+	title={node.description}
 	onmouseenter={() => (hovered = true)}
 	onmouseleave={() => (hovered = false)}
 	onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && (e.preventDefault(), open())}

--- a/src/lib/components/BeliefForm.svelte
+++ b/src/lib/components/BeliefForm.svelte
@@ -15,7 +15,7 @@
 	// Default confidence for a new belief = the middle level of the active taxonomy.
 	const midLevel = maps.confidenceLevels[Math.floor((maps.confidenceLevels.length - 1) / 2)];
 
-	let name = $state(targetNode?.name ?? '');
+	let description = $state(targetNode?.description ?? '');
 	let notes = $state(targetNode?.notes ?? '');
 	let source = $state<string>(targetNode?.source ?? '');
 	let confidence = $state<string>(targetNode?.confidence ?? midLevel?.id ?? '');
@@ -25,7 +25,7 @@
 	let attempted = $state(false);
 
 	const canPaste = $derived(mode === 'add' && ui.copied !== null);
-	const nameValid = $derived(name.trim().length > 0);
+	const descriptionValid = $derived(description.trim().length > 0);
 	const sourceValid = $derived(source.length > 0);
 
 	function addReference() {
@@ -37,7 +37,7 @@
 
 	function pasteDetails() {
 		if (!ui.copied) return;
-		name = ui.copied.name;
+		description = ui.copied.description;
 		notes = ui.copied.notes;
 		source = ui.copied.source;
 		confidence = ui.copied.confidence;
@@ -47,10 +47,10 @@
 	function submit(e: SubmitEvent) {
 		e.preventDefault();
 		attempted = true;
-		if (!nameValid || !sourceValid) return;
+		if (!descriptionValid || !sourceValid) return;
 
 		const input: BeliefInput = {
-			name: name.trim(),
+			description: description.trim(),
 			notes,
 			source,
 			confidence,
@@ -83,13 +83,14 @@
 		{/if}
 
 		<div class="field">
-			<label for="belief-name">{i18n.m.form.name}</label>
-			<input
-				id="belief-name"
-				bind:value={name}
-				placeholder={i18n.m.form.namePlaceholder}
-			/>
-			{#if attempted && !nameValid}<span class="error">{i18n.m.form.nameRequired}</span>{/if}
+			<label for="belief-description">{i18n.m.form.description}</label>
+			<textarea
+				id="belief-description"
+				rows="2"
+				bind:value={description}
+				placeholder={i18n.m.form.descriptionPlaceholder}
+			></textarea>
+			{#if attempted && !descriptionValid}<span class="error">{i18n.m.form.descriptionRequired}</span>{/if}
 		</div>
 
 		<div class="row">

--- a/src/lib/components/RerouteBelief.svelte
+++ b/src/lib/components/RerouteBelief.svelte
@@ -14,23 +14,28 @@
 	let query = $state('');
 	const filtered = $derived(
 		query.trim()
-			? candidates.filter((c) => c.name.toLowerCase().includes(query.trim().toLowerCase()))
+			? candidates.filter((c) => c.description.toLowerCase().includes(query.trim().toLowerCase()))
 			: candidates
 	);
 
 	function choose(newParentId: string) {
 		maps.applyForestOp((t) => moveNode(t, nodeId, newParentId));
 		const target = findNode(maps.roots, newParentId);
-		ui.notify(i18n.m.reroute.movedUnder({ name: node?.name ?? '', target: target?.name ?? '' }));
+		ui.notify(
+			i18n.m.reroute.movedUnder({
+				description: node?.description ?? '',
+				target: target?.description ?? ''
+			})
+		);
 		ui.closeReroute();
 	}
 </script>
 
 <Modal onclose={() => ui.closeReroute()}>
-	<h3 class="reroute-title">{i18n.m.reroute.title({ name: node?.name ?? '' })}</h3>
+	<h3 class="reroute-title">{i18n.m.reroute.title({ description: node?.description ?? '' })}</h3>
 	<p class="hint">
 		{i18n.m.reroute.hintPrefix}
-		<strong>{currentParent?.name ?? i18n.m.reroute.noParent}</strong>{i18n.m.reroute.hintSuffix}
+		<strong>{currentParent?.description ?? i18n.m.reroute.noParent}</strong>{i18n.m.reroute.hintSuffix}
 	</p>
 
 	{#if candidates.length > 8}
@@ -49,7 +54,7 @@
 				<li>
 					<button class="target" style="padding-left: {0.6 + c.depth * 0.9}rem" onclick={() => choose(c.id)}>
 						<span class="dot" style="background: {meta.colorHex}"></span>
-						<span class="name">{c.name || i18n.m.reroute.untitled}</span>
+						<span class="description">{c.description || i18n.m.reroute.untitled}</span>
 						<Icon name="chevron-right" size={16} color="var(--text-muted)" />
 					</button>
 				</li>
@@ -102,7 +107,7 @@
 		border-radius: 50%;
 		flex: none;
 	}
-	.name {
+	.description {
 		flex: 1;
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -50,9 +50,9 @@ export const de: Messages = {
 		titleAdd: ({ parent }) => `Prämisse zu „${parent}“ hinzufügen`,
 		titleInsert: ({ parent, child }) => `Überzeugung zwischen „${parent}“ und „${child}“ einfügen`,
 		paste: 'Kopierte Details einfügen',
-		name: 'Name',
-		namePlaceholder: 'Ein kurzer Name für diese Überzeugung',
-		nameRequired: 'Sie müssen einen Namen eingeben',
+		description: 'Beschreibung',
+		descriptionPlaceholder: 'Beschreiben Sie diese Überzeugung',
+		descriptionRequired: 'Sie müssen eine Beschreibung eingeben',
 		source: 'Quelle der Begründung',
 		chooseCategory: 'Kategorie wählen…',
 		sourceRequired: 'Sie müssen eine Quelle wählen',
@@ -76,14 +76,14 @@ export const de: Messages = {
 		wouldLoop: 'Das würde eine Schleife erzeugen'
 	},
 	node: {
-		belief: ({ name }) => `Überzeugung: ${name}`,
+		belief: ({ description }) => `Überzeugung: ${description}`,
 		editBelief: 'Überzeugung bearbeiten',
 		expand: 'Aufklappen',
 		collapse: 'Zuklappen'
 	},
 	reroute: {
-		title: ({ name }) => `„${name}“ verschieben`,
-		movedUnder: ({ name, target }) => `„${name}“ unter „${target}“ verschoben`,
+		title: ({ description }) => `„${description}“ verschieben`,
+		movedUnder: ({ description, target }) => `„${description}“ unter „${target}“ verschoben`,
 		hintPrefix: 'Wählen Sie eine neue übergeordnete Überzeugung. Das aktuelle übergeordnete Element ist ',
 		hintSuffix:
 			'. Sie können sie nicht unter sich selbst oder eine ihrer eigenen Prämissen verschieben.',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -47,9 +47,9 @@ export const en: Messages = {
 		titleAdd: ({ parent }) => `Add a premise to “${parent}”`,
 		titleInsert: ({ parent, child }) => `Insert a belief between “${parent}” and “${child}”`,
 		paste: 'Paste copied details',
-		name: 'Name',
-		namePlaceholder: 'A short name for this belief',
-		nameRequired: 'You must enter a name',
+		description: 'Description',
+		descriptionPlaceholder: 'Describe this belief',
+		descriptionRequired: 'You must enter a description',
 		source: 'Source of justification',
 		chooseCategory: 'Choose a category…',
 		sourceRequired: 'You must choose a source',
@@ -73,14 +73,14 @@ export const en: Messages = {
 		wouldLoop: 'That would create a loop'
 	},
 	node: {
-		belief: ({ name }) => `Belief: ${name}`,
+		belief: ({ description }) => `Belief: ${description}`,
 		editBelief: 'Edit belief',
 		expand: 'Expand',
 		collapse: 'Collapse'
 	},
 	reroute: {
-		title: ({ name }) => `Move “${name}”`,
-		movedUnder: ({ name, target }) => `Moved “${name}” under “${target}”`,
+		title: ({ description }) => `Move “${description}”`,
+		movedUnder: ({ description, target }) => `Moved “${description}” under “${target}”`,
 		hintPrefix: 'Choose a new parent belief. Its current parent is ',
 		hintSuffix: '. You can’t move it under itself or one of its own premises.',
 		noParent: '—',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -49,9 +49,9 @@ export const fr: Messages = {
 		titleAdd: ({ parent }) => `Ajouter une prémisse à « ${parent} »`,
 		titleInsert: ({ parent, child }) => `Insérer une croyance entre « ${parent} » et « ${child} »`,
 		paste: 'Coller les détails copiés',
-		name: 'Nom',
-		namePlaceholder: 'Un nom court pour cette croyance',
-		nameRequired: 'Vous devez saisir un nom',
+		description: 'Description',
+		descriptionPlaceholder: 'Décrivez cette croyance',
+		descriptionRequired: 'Vous devez saisir une description',
 		source: 'Source de justification',
 		chooseCategory: 'Choisir une catégorie…',
 		sourceRequired: 'Vous devez choisir une source',
@@ -75,14 +75,14 @@ export const fr: Messages = {
 		wouldLoop: 'Cela créerait une boucle'
 	},
 	node: {
-		belief: ({ name }) => `Croyance : ${name}`,
+		belief: ({ description }) => `Croyance : ${description}`,
 		editBelief: 'Modifier la croyance',
 		expand: 'Développer',
 		collapse: 'Réduire'
 	},
 	reroute: {
-		title: ({ name }) => `Déplacer « ${name} »`,
-		movedUnder: ({ name, target }) => `« ${name} » déplacée sous « ${target} »`,
+		title: ({ description }) => `Déplacer « ${description} »`,
+		movedUnder: ({ description, target }) => `« ${description} » déplacée sous « ${target} »`,
 		hintPrefix: 'Choisissez une nouvelle croyance parente. Son parent actuel est ',
 		hintSuffix:
 			'. Vous ne pouvez pas la déplacer sous elle-même ni sous l’une de ses propres prémisses.',

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -65,9 +65,9 @@ export interface Messages {
 		titleAdd: (p: { parent: string }) => string;
 		titleInsert: (p: { parent: string; child: string }) => string;
 		paste: string;
-		name: string;
-		namePlaceholder: string;
-		nameRequired: string;
+		description: string;
+		descriptionPlaceholder: string;
+		descriptionRequired: string;
 		source: string;
 		chooseCategory: string;
 		sourceRequired: string;
@@ -91,14 +91,14 @@ export interface Messages {
 		wouldLoop: string;
 	};
 	node: {
-		belief: (p: { name: string }) => string;
+		belief: (p: { description: string }) => string;
 		editBelief: string;
 		expand: string;
 		collapse: string;
 	};
 	reroute: {
-		title: (p: { name: string }) => string;
-		movedUnder: (p: { name: string; target: string }) => string;
+		title: (p: { description: string }) => string;
+		movedUnder: (p: { description: string; target: string }) => string;
 		hintPrefix: string; // before the bold parent name
 		hintSuffix: string; // after the bold parent name
 		noParent: string; // em-dash fallback for a missing current parent

--- a/src/lib/i18n/ru.ts
+++ b/src/lib/i18n/ru.ts
@@ -48,9 +48,9 @@ export const ru: Messages = {
 		titleAdd: ({ parent }) => `Добавить посылку к «${parent}»`,
 		titleInsert: ({ parent, child }) => `Вставить убеждение между «${parent}» и «${child}»`,
 		paste: 'Вставить скопированные сведения',
-		name: 'Название',
-		namePlaceholder: 'Краткое название убеждения',
-		nameRequired: 'Необходимо указать название',
+		description: 'Описание',
+		descriptionPlaceholder: 'Опишите это убеждение',
+		descriptionRequired: 'Необходимо указать описание',
 		source: 'Источник обоснования',
 		chooseCategory: 'Выберите категорию…',
 		sourceRequired: 'Необходимо выбрать источник',
@@ -74,14 +74,14 @@ export const ru: Messages = {
 		wouldLoop: 'Это создаст цикл'
 	},
 	node: {
-		belief: ({ name }) => `Убеждение: ${name}`,
+		belief: ({ description }) => `Убеждение: ${description}`,
 		editBelief: 'Изменить убеждение',
 		expand: 'Развернуть',
 		collapse: 'Свернуть'
 	},
 	reroute: {
-		title: ({ name }) => `Переместить «${name}»`,
-		movedUnder: ({ name, target }) => `«${name}» перемещено под «${target}»`,
+		title: ({ description }) => `Переместить «${description}»`,
+		movedUnder: ({ description, target }) => `«${description}» перемещено под «${target}»`,
 		hintPrefix: 'Выберите новое родительское убеждение. Текущий родитель — ',
 		hintSuffix: '. Нельзя переместить его под само себя или под одну из его посылок.',
 		noParent: '—',

--- a/src/lib/tree/layout.test.ts
+++ b/src/lib/tree/layout.test.ts
@@ -3,8 +3,8 @@ import { Confidence, Source } from '../types';
 import { addNode, addOrphan, newForest } from './operations';
 import { computeLayout, type LaidOutNode } from './layout';
 
-const belief = (name: string) => ({
-	name,
+const belief = (description: string) => ({
+	description,
 	notes: '',
 	source: Source.DirectObservation,
 	confidence: Confidence.Probable,
@@ -31,8 +31,8 @@ describe('computeLayout (root spokes)', () => {
 		expect(links).toHaveLength(3);
 		const root = byId(nodes, rid);
 		const a = byId(nodes, aId);
-		const b = nodes.find((n) => n.data.name === 'b')!;
-		const a1 = nodes.find((n) => n.data.name === 'a1')!;
+		const b = nodes.find((n) => n.data.description === 'b')!;
+		const a1 = nodes.find((n) => n.data.description === 'a1')!;
 		// every descendant hangs below its ancestor
 		expect(a.y).toBeGreaterThan(root.y);
 		expect(b.y).toBeGreaterThan(root.y);
@@ -45,7 +45,7 @@ describe('computeLayout (root spokes)', () => {
 		for (const n of ['south', 'west', 'north', 'east']) roots = addNode(roots, rid, belief(n));
 		const { nodes } = computeLayout(roots, new Set(), 4);
 		const root = byId(nodes, rid);
-		const dir = (name: string) => nodes.find((n) => n.data.name === name)!;
+		const dir = (name: string) => nodes.find((n) => n.data.description === name)!;
 		const near = (a: number, b: number) => Math.abs(a - b) < 1;
 
 		expect(dir('south').y).toBeGreaterThan(root.y);
@@ -76,10 +76,10 @@ describe('computeLayout (root spokes)', () => {
 		const a = byId(nodes, aId);
 		// 'a' went south; its grandchildren continue further south, not re-branched
 		expect(a.y).toBeGreaterThan(root.y);
-		expect(nodes.find((n) => n.data.name === 'a1')!.y).toBeGreaterThan(a.y);
-		expect(nodes.find((n) => n.data.name === 'a2')!.y).toBeGreaterThan(a.y);
+		expect(nodes.find((n) => n.data.description === 'a1')!.y).toBeGreaterThan(a.y);
+		expect(nodes.find((n) => n.data.description === 'a2')!.y).toBeGreaterThan(a.y);
 		// 'b' went west
-		expect(nodes.find((n) => n.data.name === 'b')!.x).toBeLessThan(root.x);
+		expect(nodes.find((n) => n.data.description === 'b')!.x).toBeLessThan(root.x);
 	});
 
 	it('tiles multiple roots into separate, horizontally-offset clusters', () => {
@@ -102,7 +102,7 @@ describe('computeLayout (root spokes)', () => {
 	it('hides the subtree of a collapsed node', () => {
 		const { roots, aId } = sample();
 		const { nodes } = computeLayout(roots, new Set([aId]), 4);
-		const names = nodes.map((n) => n.data.name);
+		const names = nodes.map((n) => n.data.description);
 		expect(names).toContain('a');
 		expect(names).not.toContain('a1');
 		expect(byId(nodes, aId).collapsed).toBe(true);

--- a/src/lib/tree/operations.test.ts
+++ b/src/lib/tree/operations.test.ts
@@ -22,11 +22,11 @@ import {
 } from './operations';
 
 const input = (
-	name: string,
+	description: string,
 	source = Source.DirectObservation,
 	confidence = Confidence.Probable
 ) => ({
-	name,
+	description,
 	notes: '',
 	source,
 	confidence,
@@ -41,7 +41,7 @@ describe('newForest / newTree / createBelief', () => {
 		const roots = newForest();
 		expect(roots).toHaveLength(1);
 		expect(roots[0].isRoot).toBe(true);
-		expect(roots[0].name).toBe('Your Beliefs');
+		expect(roots[0].description).toBe('Your Beliefs');
 		expect(roots[0].children).toEqual([]);
 	});
 
@@ -60,7 +60,7 @@ describe('addNode / addOrphan', () => {
 		expect(next).not.toBe(roots);
 		expect(roots[0].children).toHaveLength(0); // original untouched
 		expect(next[0].children).toHaveLength(1);
-		expect(next[0].children[0].name).toBe('child');
+		expect(next[0].children[0].description).toBe('child');
 	});
 
 	it('addOrphan appends a new parentless root', () => {
@@ -68,7 +68,7 @@ describe('addNode / addOrphan', () => {
 		roots = addOrphan(roots, input('loner'), { x: 10, y: 20 });
 		expect(roots).toHaveLength(2);
 		const loner = roots[1];
-		expect(loner.name).toBe('loner');
+		expect(loner.description).toBe('loner');
 		expect(loner.isRoot).toBe(true);
 		expect(loner.position).toEqual({ x: 10, y: 20 });
 		expect(findParent(roots, loner.id)).toBeNull(); // truly parentless
@@ -81,14 +81,14 @@ describe('updateNode', () => {
 		roots = addNode(roots, rootId(roots), input('old'));
 		const id = roots[0].children[0].id;
 		const next = updateNode(roots, id, {
-			name: 'new',
+			description: 'new',
 			notes: 'note',
 			source: Source.ScientificEvidence,
 			confidence: Confidence.Established,
 			references: [{ text: 'r', link: 'http://x' }]
 		});
 		const updated = findNode(next, id)!;
-		expect(updated.name).toBe('new');
+		expect(updated.description).toBe('new');
 		expect(updated.source).toBe(Source.ScientificEvidence);
 		expect(updated.confidence).toBe(Confidence.Established);
 		expect(updated.references[0].link).toBe('http://x');
@@ -105,7 +105,7 @@ describe('deleteNode', () => {
 
 		const next = deleteNode(roots, midId);
 		expect(next[0].children).toHaveLength(2);
-		expect(next[0].children.map((c) => c.name).sort()).toEqual(['leaf1', 'leaf2']);
+		expect(next[0].children.map((c) => c.description).sort()).toEqual(['leaf1', 'leaf2']);
 	});
 
 	it('deleting a root promotes its children to roots', () => {
@@ -113,7 +113,7 @@ describe('deleteNode', () => {
 		roots = addNode(roots, rootId(roots), input('a'));
 		roots = addNode(roots, rootId(roots), input('b'));
 		const next = deleteNode(roots, rootId(roots));
-		expect(next.map((r) => r.name).sort()).toEqual(['a', 'b']);
+		expect(next.map((r) => r.description).sort()).toEqual(['a', 'b']);
 		expect(next.every((r) => r.isRoot)).toBe(true);
 	});
 });
@@ -137,8 +137,8 @@ describe('reroute (moveNode / canReroute) — forest', () => {
 		const { roots, aId, bId } = sample();
 		const next = moveNode(roots, aId, bId);
 		const b = findNode(next, bId)!;
-		expect(b.children.map((c) => c.name)).toEqual(['a']);
-		expect(b.children[0].children[0].name).toBe('a1'); // subtree came along
+		expect(b.children.map((c) => c.description)).toEqual(['a']);
+		expect(b.children[0].children[0].description).toBe('a1'); // subtree came along
 	});
 
 	it('re-parents an orphan root under a node (root loses root status)', () => {
@@ -182,9 +182,9 @@ describe('insertBetween', () => {
 
 		const next = insertBetween(roots, rootId(roots), childId, input('bridge'));
 		const mid = next[0].children[0];
-		expect(mid.name).toBe('bridge');
+		expect(mid.description).toBe('bridge');
 		expect(mid.children[0].id).toBe(childId);
-		expect(mid.children[0].children[0].name).toBe('grandchild');
+		expect(mid.children[0].children[0].description).toBe('grandchild');
 	});
 
 	it('is a no-op when childId is not a direct child of parentId', () => {
@@ -224,6 +224,8 @@ describe('normalizeMap', () => {
 		expect(doc.roots).toHaveLength(1);
 		const t = doc.roots[0];
 		expect(t.source).toBe(Source.LogicalReasoning);
+		expect(t.description).toBe('Your Beliefs'); // legacy `name` migrates to `description`
+		expect(t.children[0].description).toBe('sci');
 		expect(t.children[0]).toMatchObject({ source: Source.ScientificEvidence, confidence: Confidence.Established });
 		expect(t.children[1]).toMatchObject({ source: Source.ExpertAuthority, confidence: Confidence.Probable });
 		expect(t.children[2]).toMatchObject({ source: Source.Faith, confidence: Confidence.Probable });

--- a/src/lib/tree/operations.ts
+++ b/src/lib/tree/operations.ts
@@ -39,7 +39,7 @@ function uuid(): string {
 export function createBelief(input: BeliefInput, isRoot = false): BeliefNode {
 	return {
 		id: uuid(),
-		name: input.name,
+		description: input.description,
 		notes: input.notes,
 		source: input.source,
 		confidence: input.confidence,
@@ -50,16 +50,16 @@ export function createBelief(input: BeliefInput, isRoot = false): BeliefNode {
 }
 
 /** A single seeded root belief. */
-export function newTree(name = 'Your Beliefs'): BeliefNode {
+export function newTree(description = 'Your Beliefs'): BeliefNode {
 	return createBelief(
-		{ name, notes: '', source: Source.LogicalReasoning, confidence: Confidence.Established, references: [] },
+		{ description, notes: '', source: Source.LogicalReasoning, confidence: Confidence.Established, references: [] },
 		true
 	);
 }
 
 /** A brand-new forest (one seeded root). */
-export function newForest(name = 'Your Beliefs'): BeliefNode[] {
-	return [newTree(name)];
+export function newForest(description = 'Your Beliefs'): BeliefNode[] {
+	return [newTree(description)];
 }
 
 /** Structural clone of a node subtree. */
@@ -152,7 +152,7 @@ export function addOrphan(
 /** Update the fields of the node identified by `id`. Returns a new forest. */
 export function updateNode(roots: BeliefNode[], id: string, patch: BeliefInput): BeliefNode[] {
 	return mutateNode(roots, id, (node) => {
-		node.name = patch.name;
+		node.description = patch.description;
 		node.notes = patch.notes;
 		node.source = patch.source;
 		node.confidence = patch.confidence;
@@ -221,15 +221,15 @@ export function moveNode(roots: BeliefNode[], id: string, newParentId: string): 
 export function rerouteCandidates(
 	roots: BeliefNode[],
 	id: string
-): { id: string; name: string; source: string; depth: number }[] {
+): { id: string; description: string; source: string; depth: number }[] {
 	const node = findNode(roots, id);
 	if (!node) return [];
 	const blocked = subtreeIds(node); // self + descendants
 	const currentParent = findParent(roots, id);
-	const out: { id: string; name: string; source: string; depth: number }[] = [];
+	const out: { id: string; description: string; source: string; depth: number }[] = [];
 	const walk = (n: BeliefNode, depth: number) => {
 		const isBlocked = blocked.has(n.id) || currentParent?.id === n.id;
-		if (!isBlocked) out.push({ id: n.id, name: n.name, source: n.source, depth });
+		if (!isBlocked) out.push({ id: n.id, description: n.description, source: n.source, depth });
 		for (const child of n.children) walk(child, depth + 1);
 	};
 	for (const r of roots) walk(r, 0);
@@ -403,7 +403,13 @@ function normalizeNode(
 		p && typeof p.x === 'number' && typeof p.y === 'number' ? { x: p.x, y: p.y } : undefined;
 	return {
 		id: typeof obj.id === 'string' && obj.id ? obj.id : uuid(),
-		name: typeof obj.name === 'string' ? obj.name : '',
+		// Read `description`, falling back to the legacy `name` field for old JSON.
+		description:
+			typeof obj.description === 'string'
+				? obj.description
+				: typeof obj.name === 'string'
+					? obj.name
+					: '',
 		notes: typeof obj.notes === 'string' ? obj.notes : '',
 		source: resolveId(obj.source, catIds, legacy?.source ?? null, fallbackCat),
 		confidence: resolveId(obj.confidence, levelIds, legacy?.confidence ?? null, fallbackLevel),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,7 +43,7 @@ export interface BeliefReference {
  *  ConfidenceLevel in the owning map's taxonomy, by id. Recursive via `children`. */
 export interface BeliefNode {
 	id: string;
-	name: string;
+	description: string;
 	notes: string;
 	source: string;
 	confidence: string;
@@ -66,7 +66,7 @@ export interface BeliefMapDoc {
 /** The editable payload of a belief (everything a form collects). */
 export type BeliefInput = Pick<
 	BeliefNode,
-	'name' | 'notes' | 'source' | 'confidence' | 'references'
+	'description' | 'notes' | 'source' | 'confidence' | 'references'
 >;
 
 /** Metadata for a saved map, kept in the persistence index. */


### PR DESCRIPTION
A belief's primary text is a description (can be a full sentence), not a name. Renamed BeliefNode.name -> description across the model, operations, components, i18n (all four locales), and tests; the form is a textarea. normalizeMap reads 'description' with a legacy 'name' fallback so old JSON still imports. Map names and category/preset labels are unchanged.