### PR TITLE
Map existing categories individually when switching presets

### DIFF
--- a/src/lib/beliefTypes.test.ts
+++ b/src/lib/beliefTypes.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { completePresetMapping, presets, PRESET_REMAP_SUGGESTIONS } from './beliefTypes';
+import { en } from './i18n/en';
+
+const all = presets(en);
+const byId = (id: string) => all.find((p) => p.id === id)!;
+
+describe('PRESET_REMAP_SUGGESTIONS', () => {
+	// A typo'd id would silently degrade to the first-category fallback, so pin
+	// every key/value to a real preset id.
+	it('targets only ids that exist in the named preset', () => {
+		for (const [presetId, table] of Object.entries(PRESET_REMAP_SUGGESTIONS)) {
+			const target = byId(presetId);
+			expect(target).toBeDefined();
+			const targetIds = new Set(target.categories.map((c) => c.id));
+			for (const to of Object.values(table)) expect(targetIds).toContain(to);
+		}
+	});
+
+	it('keys are ids from the other presets', () => {
+		const allIds = new Set(all.flatMap((p) => p.categories.map((c) => c.id)));
+		for (const table of Object.values(PRESET_REMAP_SUGGESTIONS)) {
+			for (const from of Object.keys(table)) expect(allIds).toContain(from);
+		}
+	});
+});
+
+describe('completePresetMapping', () => {
+	const dikw = byId('dikw');
+
+	it('prefers a valid partial target, then identity, then suggestion, then first', () => {
+		const mapping = completePresetMapping(
+			dikw,
+			['data', 'faith', 'tradition', 'custom-uuid'],
+			{ data: 'wisdom', tradition: 'not-a-dikw-id' }
+		);
+		expect(mapping).toEqual({
+			data: 'wisdom', // partial target wins
+			faith: 'belief', // no identity in DIKW → suggestion
+			tradition: 'belief', // invalid partial target → suggestion
+			'custom-uuid': 'data' // unknown id → first category
+		});
+	});
+
+	it('defaults to identity for overlapping ids when no partial is given', () => {
+		expect(completePresetMapping(dikw, ['knowledge'])).toEqual({ knowledge: 'knowledge' });
+	});
+});

--- a/src/lib/beliefTypes.ts
+++ b/src/lib/beliefTypes.ts
@@ -98,6 +98,77 @@ export function presets(m: Messages): Preset[] {
 	];
 }
 
+/** Default remap targets when switching presets: targetPresetId → (oldId → newId).
+ *  Consulted only when the old category id doesn't already exist in the target set;
+ *  unknown ids (e.g. custom categories) fall back to the target set's first category. */
+export const PRESET_REMAP_SUGGESTIONS: Record<string, Record<string, string>> = {
+	'dikw': {
+		empiricalData: 'data',
+		directObservation: 'data',
+		scientificEvidence: 'knowledge',
+		logicalReasoning: 'understanding',
+		expertAuthority: 'information',
+		tradition: 'belief',
+		faith: 'belief',
+		intuition: 'speculation',
+		experience: 'data',
+		testimony: 'information',
+		reasoning: 'understanding',
+		openQuestion: 'speculation'
+	},
+	'epistemic-ladder': {
+		empiricalData: 'data',
+		directObservation: 'experience',
+		scientificEvidence: 'knowledge',
+		logicalReasoning: 'reasoning',
+		expertAuthority: 'testimony',
+		tradition: 'testimony',
+		intuition: 'belief',
+		information: 'data',
+		understanding: 'knowledge',
+		wisdom: 'knowledge',
+		speculation: 'assumption'
+	},
+	'source-of-justification': {
+		data: 'empiricalData',
+		experience: 'directObservation',
+		testimony: 'expertAuthority',
+		reasoning: 'logicalReasoning',
+		knowledge: 'scientificEvidence',
+		openQuestion: 'intuition',
+		information: 'empiricalData',
+		understanding: 'logicalReasoning',
+		wisdom: 'intuition',
+		speculation: 'intuition',
+		assumption: 'intuition',
+		belief: 'faith'
+	}
+};
+
+/** Complete a preset-switch mapping: for each old category id, prefer the given
+ *  partial target (when it exists in the preset), then the id itself, then the
+ *  semantic suggestion, then the preset's first category. Single owner of the
+ *  fallback policy — seeds the remap UI and validates the final mapping on apply. */
+export function completePresetMapping(
+	preset: Preset,
+	oldIds: string[],
+	partial: Record<string, string> = {}
+): Record<string, string> {
+	const newIds = new Set(preset.categories.map((c) => c.id));
+	const suggest = PRESET_REMAP_SUGGESTIONS[preset.id] ?? {};
+	const mapping: Record<string, string> = {};
+	for (const id of oldIds) {
+		mapping[id] = newIds.has(partial[id])
+			? partial[id]
+			: newIds.has(id)
+				? id
+				: newIds.has(suggest[id])
+					? suggest[id]
+					: preset.categories[0].id;
+	}
+	return mapping;
+}
+
 /** Confidence → fill opacity, derived from the level's order so any count renders
  *  sensibly. 3 levels → 0.4 / 0.7 / 1.0 (matches the prior fixed scale). */
 export function opacityForIndex(index: number, count: number): number {

--- a/src/lib/components/TaxonomyManager.svelte
+++ b/src/lib/components/TaxonomyManager.svelte
@@ -2,7 +2,8 @@
 	import { maps } from '$lib/stores/maps.svelte';
 	import { ui } from '$lib/stores/ui.svelte';
 	import { i18n } from '$lib/stores/i18n.svelte';
-	import { presets, SWATCHES } from '$lib/beliefTypes';
+	import { completePresetMapping, presets, SWATCHES } from '$lib/beliefTypes';
+	import type { Category } from '$lib/types';
 	import { countByCategory, countByConfidence } from '$lib/tree/operations';
 	import Modal from './Modal.svelte';
 	import Icon from './Icon.svelte';
@@ -23,8 +24,14 @@
 		targetId: string;
 	} | null>(null);
 
-	// Pending preset application (choose fallback for orphaned beliefs).
-	let presetPending = $state<{ presetId: string; name: string; fallbackId: string } | null>(null);
+	// Pending preset application: map each in-use category to one of the new set.
+	let presetPending = $state<{
+		presetId: string;
+		name: string;
+		categories: Category[]; // new set (select options)
+		rows: { oldId: string; label: string; count: number }[]; // in-use old categories
+		mapping: Record<string, string>; // oldId → newId, bound to selects
+	} | null>(null);
 
 	function newId() {
 		return crypto.randomUUID();
@@ -75,11 +82,21 @@
 	function choosePreset(presetId: string) {
 		const preset = presets(i18n.m).find((p) => p.id === presetId);
 		if (!preset) return;
-		presetPending = { presetId, name: preset.name, fallbackId: preset.categories[0].id };
+		const inUse = maps.categories.filter((c) => (catCounts[c.id] ?? 0) > 0);
+		presetPending = {
+			presetId,
+			name: preset.name,
+			categories: preset.categories,
+			rows: inUse.map((c) => ({ oldId: c.id, label: c.label, count: catCounts[c.id] })),
+			mapping: completePresetMapping(
+				preset,
+				inUse.map((c) => c.id)
+			)
+		};
 	}
 	function confirmPreset() {
 		if (!presetPending) return;
-		maps.applyPreset(presetPending.presetId, presetPending.fallbackId);
+		maps.applyPreset(presetPending.presetId, presetPending.mapping);
 		presetPending = null;
 	}
 
@@ -108,12 +125,25 @@
 		</div>
 	{:else if presetPending}
 		<div class="remap">
-			<p>{i18n.m.taxonomy.applyPresetPrompt({ name: presetPending.name })}</p>
-			<select bind:value={presetPending.fallbackId}>
-				{#each presets(i18n.m).find((p) => p.id === presetPending!.presetId)!.categories as c (c.id)}
-					<option value={c.id}>{c.label}</option>
-				{/each}
-			</select>
+			{#if presetPending.rows.length > 0}
+				<p>{i18n.m.taxonomy.applyPresetMapPrompt({ name: presetPending.name })}</p>
+				<ul class="rows map-rows">
+					{#each presetPending.rows as row (row.oldId)}
+						<li>
+							<span class="map-old">{row.label}</span>
+							<span class="count">{row.count}</span>
+							<span class="map-arrow">→</span>
+							<select bind:value={presetPending.mapping[row.oldId]}>
+								{#each presetPending.categories as c (c.id)}
+									<option value={c.id}>{c.label}</option>
+								{/each}
+							</select>
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<p>{i18n.m.taxonomy.applyPresetEmptyPrompt({ name: presetPending.name })}</p>
+			{/if}
 			<div class="actions">
 				<button class="btn" onclick={() => (presetPending = null)}>{i18n.m.taxonomy.cancel}</button>
 				<button class="btn btn-primary" onclick={confirmPreset}>{i18n.m.taxonomy.applyPreset}</button>
@@ -389,6 +419,27 @@
 		border-radius: 7px;
 		background: var(--surface);
 		color: var(--text);
+	}
+	.map-rows {
+		max-height: 320px;
+		overflow-y: auto;
+	}
+	.map-old {
+		flex: 1;
+		min-width: 0;
+		font-size: 0.9rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.map-arrow {
+		color: var(--text-muted);
+		flex: none;
+	}
+	.map-rows select {
+		width: auto;
+		flex: 1;
+		min-width: 0;
 	}
 	.actions {
 		display: flex;

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -105,8 +105,10 @@ export const de: Messages = {
 			`${count} ${pluralForm('de', count, { one: 'Überzeugung', other: 'Überzeugungen' })} mit „${label}“ verschieben nach:`,
 		moveAndDelete: 'Verschieben & löschen',
 		cancel: 'Abbrechen',
-		applyPresetPrompt: ({ name }) =>
-			`Vorlage ${name} laden? Sie ersetzt die aktuellen Kategorien. Überzeugungen, deren Kategorie entfällt, werden verschoben nach:`,
+		applyPresetMapPrompt: ({ name }) =>
+			`Vorlage ${name} laden? Sie ersetzt die aktuellen Kategorien. Wähle für jede bestehende Kategorie eine neue:`,
+		applyPresetEmptyPrompt: ({ name }) =>
+			`Vorlage ${name} laden? Sie ersetzt die aktuellen Kategorien.`,
 		applyPreset: 'Vorlage anwenden',
 		categories: 'Kategorien',
 		loadPreset: 'Vorlage laden',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -101,8 +101,10 @@ export const en: Messages = {
 			`Move the ${count} ${pluralForm('en', count, { one: 'belief', other: 'beliefs' })} using “${label}” to:`,
 		moveAndDelete: 'Move & delete',
 		cancel: 'Cancel',
-		applyPresetPrompt: ({ name }) =>
-			`Load the ${name} preset? It replaces the current categories. Beliefs whose category disappears move to:`,
+		applyPresetMapPrompt: ({ name }) =>
+			`Load the ${name} preset? It replaces the current categories. Choose a new category for each existing one:`,
+		applyPresetEmptyPrompt: ({ name }) =>
+			`Load the ${name} preset? It replaces the current categories.`,
 		applyPreset: 'Apply preset',
 		categories: 'Categories',
 		loadPreset: 'Load preset',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -104,8 +104,10 @@ export const fr: Messages = {
 			`Déplacer ${count} ${pluralForm('fr', count, { one: 'croyance', other: 'croyances' })} utilisant « ${label} » vers :`,
 		moveAndDelete: 'Déplacer et supprimer',
 		cancel: 'Annuler',
-		applyPresetPrompt: ({ name }) =>
-			`Charger le modèle ${name} ? Il remplace les catégories actuelles. Les croyances dont la catégorie disparaît seront déplacées vers :`,
+		applyPresetMapPrompt: ({ name }) =>
+			`Charger le modèle ${name} ? Il remplace les catégories actuelles. Choisissez une nouvelle catégorie pour chacune des catégories existantes :`,
+		applyPresetEmptyPrompt: ({ name }) =>
+			`Charger le modèle ${name} ? Il remplace les catégories actuelles.`,
 		applyPreset: 'Appliquer le modèle',
 		categories: 'Catégories',
 		loadPreset: 'Charger un modèle',

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -118,7 +118,8 @@ export interface Messages {
 		remapPrompt: (p: { count: number; label: string }) => string; // plural
 		moveAndDelete: string;
 		cancel: string;
-		applyPresetPrompt: (p: { name: string }) => string;
+		applyPresetMapPrompt: (p: { name: string }) => string;
+		applyPresetEmptyPrompt: (p: { name: string }) => string;
 		applyPreset: string;
 		categories: string;
 		loadPreset: string;

--- a/src/lib/i18n/ru.ts
+++ b/src/lib/i18n/ru.ts
@@ -102,8 +102,10 @@ export const ru: Messages = {
 			`Переместить ${count} ${pluralForm('ru', count, { one: 'убеждение', few: 'убеждения', many: 'убеждений', other: 'убеждений' })} из «${label}» в:`,
 		moveAndDelete: 'Переместить и удалить',
 		cancel: 'Отмена',
-		applyPresetPrompt: ({ name }) =>
-			`Загрузить набор «${name}»? Он заменит текущие категории. Убеждения, чья категория исчезает, будут перемещены в:`,
+		applyPresetMapPrompt: ({ name }) =>
+			`Загрузить набор «${name}»? Он заменит текущие категории. Выберите новую категорию для каждой существующей:`,
+		applyPresetEmptyPrompt: ({ name }) =>
+			`Загрузить набор «${name}»? Он заменит текущие категории.`,
 		applyPreset: 'Применить набор',
 		categories: 'Категории',
 		loadPreset: 'Загрузить набор',

--- a/src/lib/stores/maps.svelte.ts
+++ b/src/lib/stores/maps.svelte.ts
@@ -4,12 +4,19 @@ import {
 	addOrphan as addOrphanOp,
 	clearPositions,
 	newForest,
+	reassignCategories,
 	reassignCategory,
 	reassignConfidence,
 	setPosition
 } from '../tree/operations';
 import type { BeliefInput } from '../types';
-import { defaultCategories, defaultConfidenceLevels, presets, opacityForIndex } from '../beliefTypes';
+import {
+	completePresetMapping,
+	defaultCategories,
+	defaultConfidenceLevels,
+	presets,
+	opacityForIndex
+} from '../beliefTypes';
 import {
 	clearAll,
 	loadActiveId,
@@ -221,19 +228,19 @@ class MapsStore {
 
 	// --- Taxonomy mutations --------------------------------------------------
 
-	applyPreset(presetId: string, fallbackId: string): void {
+	/** Replace the categories with a preset's, remapping beliefs per `mapping`
+	 *  (oldId → newId). `completePresetMapping` fills gaps and coerces invalid
+	 *  targets, so no belief ends up on a nonexistent category. */
+	applyPreset(presetId: string, mapping: Record<string, string> = {}): void {
 		const preset = presets(i18n.m).find((p) => p.id === presetId);
 		if (!preset) return;
-		const next = preset.categories.map((c) => ({ ...c }));
-		const validId = next.some((c) => c.id === fallbackId) ? fallbackId : next[0].id;
-		const newIds = new Set(next.map((c) => c.id));
-		// Remap any belief whose category no longer exists to the fallback.
-		let roots = this.roots;
-		for (const id of new Set(this.categories.map((c) => c.id))) {
-			if (!newIds.has(id)) roots = reassignCategory(roots, id, validId);
-		}
-		this.categories = next;
-		this.roots = roots;
+		const effective = completePresetMapping(
+			preset,
+			this.categories.map((c) => c.id),
+			mapping
+		);
+		this.roots = reassignCategories(this.roots, effective);
+		this.categories = preset.categories.map((c) => ({ ...c }));
 		this.persist();
 	}
 

--- a/src/lib/tree/operations.test.ts
+++ b/src/lib/tree/operations.test.ts
@@ -16,6 +16,7 @@ import {
 	newForest,
 	newTree,
 	normalizeMap,
+	reassignCategories,
 	reassignCategory,
 	rerouteCandidates,
 	setPosition,
@@ -289,5 +290,46 @@ describe('reassignCategory / counts', () => {
 		const next = reassignCategory(roots, Source.Faith, Source.Intuition);
 		expect(countByCategory(next)[Source.Faith]).toBeUndefined();
 		expect(countByCategory(next)[Source.Intuition]).toBe(3);
+	});
+});
+
+describe('reassignCategories', () => {
+	const forest = () => {
+		let roots = newForest();
+		roots = addNode(roots, rootId(roots), input('a', Source.Faith));
+		roots = addNode(roots, rootId(roots), input('b', Source.Intuition));
+		roots = addOrphan(roots, input('c', Source.Tradition));
+		return roots;
+	};
+
+	it('applies a chained mapping in a single pass (A→B while B→C)', () => {
+		const next = reassignCategories(forest(), {
+			[Source.Faith]: Source.Intuition,
+			[Source.Intuition]: Source.Tradition
+		});
+		const counts = countByCategory(next);
+		// Former-Faith beliefs land on Intuition and stay there — no double remap.
+		expect(counts[Source.Intuition]).toBe(1);
+		expect(counts[Source.Tradition]).toBe(2);
+		expect(counts[Source.Faith]).toBeUndefined();
+	});
+
+	it('swaps two categories cleanly', () => {
+		const next = reassignCategories(forest(), {
+			[Source.Faith]: Source.Intuition,
+			[Source.Intuition]: Source.Faith
+		});
+		const counts = countByCategory(next);
+		expect(counts[Source.Faith]).toBe(1);
+		expect(counts[Source.Intuition]).toBe(1);
+		expect(counts[Source.Tradition]).toBe(1);
+	});
+
+	it('leaves ids absent from the mapping unchanged and does not mutate the input', () => {
+		const roots = forest();
+		const next = reassignCategories(roots, { [Source.Faith]: Source.EmpiricalData });
+		expect(countByCategory(next)[Source.Intuition]).toBe(1);
+		expect(countByCategory(next)[Source.Tradition]).toBe(1);
+		expect(countByCategory(roots)[Source.Faith]).toBe(1);
 	});
 });

--- a/src/lib/tree/operations.ts
+++ b/src/lib/tree/operations.ts
@@ -289,26 +289,35 @@ export function clearPositions(roots: BeliefNode[]): BeliefNode[] {
 
 // --- Taxonomy reassignment (used by delete / preset-switch) -----------------
 
-/** Point every belief whose `key` id is `fromId` at `toId`. Returns a new forest. */
+/** Rewrite each belief's `key` id through `mapping` (oldId → newId) in a single
+ *  pass, so chained mappings (A→B while B→C) never double-remap a node. Ids
+ *  absent from the mapping are left unchanged. Returns a new forest. */
 function reassign(
 	roots: BeliefNode[],
 	key: 'source' | 'confidence',
-	fromId: string,
-	toId: string
+	mapping: Record<string, string>
 ): BeliefNode[] {
 	const next = cloneForest(roots);
 	walkForest(next, (n) => {
-		if (n[key] === fromId) n[key] = toId;
+		const to = mapping[n[key]];
+		if (to !== undefined) n[key] = to;
 	});
 	return next;
 }
 
 export function reassignCategory(roots: BeliefNode[], fromId: string, toId: string): BeliefNode[] {
-	return reassign(roots, 'source', fromId, toId);
+	return reassign(roots, 'source', { [fromId]: toId });
 }
 
 export function reassignConfidence(roots: BeliefNode[], fromId: string, toId: string): BeliefNode[] {
-	return reassign(roots, 'confidence', fromId, toId);
+	return reassign(roots, 'confidence', { [fromId]: toId });
+}
+
+export function reassignCategories(
+	roots: BeliefNode[],
+	mapping: Record<string, string>
+): BeliefNode[] {
+	return reassign(roots, 'source', mapping);
 }
 
 function countBy(roots: BeliefNode[], key: 'source' | 'confidence'): Record<string, number> {


### PR DESCRIPTION
## Summary

Loading a category preset (Source of justification / Epistemic ladder / DIKW) previously collapsed every disappearing category onto a single fallback category. The confirmation panel now shows a mapping table — one row per in-use category with its belief count and a select of the new set — so each existing category maps to its own target.

- **Smart defaults**: chosen target → identity (ids like `data`/`knowledge`/`belief` overlap across presets) → curated semantic suggestion (`PRESET_REMAP_SUGGESTIONS`, e.g. `faith → belief` when switching to DIKW) → first category. The policy has a single owner, `completePresetMapping` in `beliefTypes.ts`, which both seeds the UI selects and validates the final mapping in `maps.applyPreset`.
- **Single-pass remap**: the private `reassign` helper in `tree/operations.ts` now rewrites node ids through a mapping in one traversal, so chained mappings (A→B while B→C) never double-remap a node. `reassignCategory` / `reassignConfidence` / `reassignCategories` are thin wrappers over it.
- **i18n**: `applyPresetPrompt` replaced by `applyPresetMapPrompt` / `applyPresetEmptyPrompt` in en/de/fr/ru; maps with no beliefs get a plain confirm with no table.

## Testing

- `npm test`: 46/46 passing, including new cases for chained/swap mappings, `PRESET_REMAP_SUGGESTIONS` id integrity (a typo'd id would silently degrade to the first-category fallback), and `completePresetMapping` precedence.
- `npm run check`: clean.
- Playwright drive of the real app: seeded beliefs across default + custom categories, loaded the DIKW preset, verified rows/counts/suggested defaults, applied a deliberately chained override (`Empirical data → Wisdom` while `Faith → Data`) with no double-remap in the stored JSON, plus persistence across reload, empty-map confirm, and cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)